### PR TITLE
Recolor GitHub Corner to Match Site

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -469,8 +469,8 @@ textarea {
 }
 
 .github-corner svg {
-  fill: #151513;
-  color: #fff;
+  fill: #fff;
+  color: #7a65dd;
   position: absolute;
   top: 0;
   border: 0;


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/get-alex/alex/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->
A GitHub corner was added to the website in #204. I noticed that it's colors clash a bit with the website's landing page. This pull request changes the colors of the corner to make it fit the style of the site a bit more. 

_(Relates to #200)_