### PR TITLE
 Add HTML parsing to core API.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,16 +4,19 @@ var VFile = require('vfile')
 var unified = require('unified')
 var markdown = require('remark-parse')
 var frontmatter = require('remark-frontmatter')
+var html = require('rehype-parse')
 var english = require('retext-english')
 var equality = require('retext-equality')
 var profanities = require('retext-profanities')
 var remark2retext = require('remark-retext')
+var rehype2retext = require('rehype-retext')
 var sort = require('vfile-sort')
 var filter = require('./filter')
 
 module.exports = alex
 alex.text = noMarkdown
 alex.markdown = alex
+alex.html = htmlParse
 
 var text = unified()
   .use(english)
@@ -40,6 +43,17 @@ function alex(value, allow) {
       .use(markdown)
       .use(frontmatter, ['yaml', 'toml'])
       .use(remark2retext, text)
+      .use(filter, {allow: allow})
+  )
+}
+
+// Alex, for HTML.
+function htmlParse(value, allow) {
+  return core(
+    value,
+    unified()
+      .use(html)
+      .use(rehype2retext, text)
       .use(filter, {allow: allow})
   )
 }

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ Give **alex** a spin on the [Online demo »][demo].
 *   [x] Helps to get better at considerate writing
 *   [x] Catches many possible offences
 *   [x] Suggests helpful alternatives
-*   [x] Reads plain-text and markdown as input
+*   [x] Reads plain-text, HTML, and markdown as input
 *   [x] Stylish
 
 ## Install
@@ -47,6 +47,7 @@ $ npm install alex --global
     *   [alex(value\[, allow\])](#alexvalue-allow)
     *   [alex.markdown(value\[, allow\])](#alexmarkdownvalue-allow)
     *   [alex.text(value)](#alextextvalue)
+    *   [alex.html(value)](#alexhtmlvalue)
 *   [Integrations](#integrations)
 *   [Support](#support)
 *   [Ignoring files](#ignoring-files)
@@ -143,6 +144,42 @@ Yields:
 [`VFile`][vfile].  You’ll probably be interested in its
 [`messages`][vfile-message] property, as demonstrated in the example
 above, as it holds the possible violations.
+
+### `alex.html(value)`
+
+Works just like [`alex()`][alex-api] and [`alex.text()`](#alextextvalue), but parses it as HTML.
+It will break your writing out of it's HTML-wrapped tags and examine them.
+
+###### Example
+
+```js
+alex.html('<button disabled>Press me</button><p class="black">He walked to class.</p>').messages // => []
+```
+
+Yields:
+
+```js
+[ { [1:52-1:54: `He` may be insensitive, use `They`, `It` instead]
+    message: '`He` may be insensitive, use `They`, `It` instead',
+    name: '1:52-1:54',
+    reason: '`He` may be insensitive, use `They`, `It` instead',
+    line: 1,
+    column: 52,
+    location: { start: [Object], end: [Object] },
+    source: 'retext-equality',
+    ruleId: 'he-she',
+    fatal: false },
+  { [1:52-1:54: `He` may be insensitive, use `They`, `It` instead]
+    message: '`He` may be insensitive, use `They`, `It` instead',
+    name: '1:52-1:54',
+    reason: '`He` may be insensitive, use `They`, `It` instead',
+    line: 1,
+    column: 52,
+    location: { start: [Object], end: [Object] },
+    source: 'retext-equality',
+    ruleId: 'he-she',
+    fatal: false } ]
+```
 
 ### `alex.text(value)`
 

--- a/readme.md
+++ b/readme.md
@@ -46,8 +46,8 @@ $ npm install alex --global
 *   [API](#api)
     *   [alex(value\[, allow\])](#alexvalue-allow)
     *   [alex.markdown(value\[, allow\])](#alexmarkdownvalue-allow)
-    *   [alex.text(value)](#alextextvalue)
     *   [alex.html(value)](#alexhtmlvalue)
+    *   [alex.text(value)](#alextextvalue)
 *   [Integrations](#integrations)
 *   [Support](#support)
 *   [Ignoring files](#ignoring-files)
@@ -148,7 +148,7 @@ above, as it holds the possible violations.
 ### `alex.html(value)`
 
 Works just like [`alex()`][alex-api] and [`alex.text()`](#alextextvalue), but parses it as HTML.
-It will break your writing out of it's HTML-wrapped tags and examine them.
+It will break your writing out of it’s HTML-wrapped tags and examine them.
 
 ###### Example
 

--- a/readme.md
+++ b/readme.md
@@ -153,28 +153,18 @@ It will break your writing out of it’s HTML-wrapped tags and examine them.
 ###### Example
 
 ```js
-alex.html('<button disabled>Press me</button><p class="black">He walked to class.</p>').messages // => []
+alex.html('<p class="black">He walked to class.</p>').messages
 ```
 
 Yields:
 
 ```js
-[ { [1:52-1:54: `He` may be insensitive, use `They`, `It` instead]
+[ { [1:18-1:20: `He` may be insensitive, use `They`, `It` instead]
     message: '`He` may be insensitive, use `They`, `It` instead',
-    name: '1:52-1:54',
+    name: '1:18-1:20',
     reason: '`He` may be insensitive, use `They`, `It` instead',
     line: 1,
-    column: 52,
-    location: { start: [Object], end: [Object] },
-    source: 'retext-equality',
-    ruleId: 'he-she',
-    fatal: false },
-  { [1:52-1:54: `He` may be insensitive, use `They`, `It` instead]
-    message: '`He` may be insensitive, use `They`, `It` instead',
-    name: '1:52-1:54',
-    reason: '`He` may be insensitive, use `They`, `It` instead',
-    line: 1,
-    column: 52,
+    column: 18,
     location: { start: [Object], end: [Object] },
     source: 'retext-equality',
     ruleId: 'he-she',

--- a/test/api.js
+++ b/test/api.js
@@ -43,7 +43,9 @@ test('alex.text()', function(t) {
 
 test('alex.html()', function(t) {
   t.deepEqual(
-    alex.html(`
+    alex
+      .html(
+        `
       <!doctype html>
       <html>
       <!-- The Chinese student walked to class. -->
@@ -57,11 +59,12 @@ test('alex.html()', function(t) {
       <code>var adult = 2</code>
       </body>
       </html>
-      `)
-    .messages
-    .map(String), [
+      `
+      )
+      .messages.map(String),
+    [
       '10:24-10:26: `He` may be insensitive, use `They`, `It` instead',
-      '11:7-11:10: `She` may be insensitive, use `They`, `It` instead',
+      '11:7-11:10: `She` may be insensitive, use `They`, `It` instead'
     ]
   )
 })

--- a/test/api.js
+++ b/test/api.js
@@ -40,3 +40,28 @@ test('alex.text()', function(t) {
     '1:6-1:15: `boogeyman` may be insensitive, use `boogey` instead'
   ])
 })
+
+test('alex.html()', function(t) {
+  t.deepEqual(
+    alex.html(`
+      <!doctype html>
+      <html>
+      <!-- The Chinese student walked to class. -->
+      <head><title>Church website</title></head>
+      <body>
+      <script>console.log("The boogeyman walked to class.")</script>
+      <style>.black {color: black;}</style>
+      <button disabled>Press me</button>
+      <p class="black">He walked to class.</p>
+      She walked to class.
+      <code>var adult = 2</code>
+      </body>
+      </html>
+      `)
+    .messages
+    .map(String), [
+      '10:24-10:26: `He` may be insensitive, use `They`, `It` instead',
+      '11:7-11:10: `She` may be insensitive, use `They`, `It` instead',
+    ]
+  )
+})

--- a/test/api.js
+++ b/test/api.js
@@ -1,5 +1,7 @@
 'use strict'
 
+var fs = require('fs')
+var path = require('path')
 var test = require('ava')
 var alex = require('..')
 
@@ -42,29 +44,11 @@ test('alex.text()', function(t) {
 })
 
 test('alex.html()', function(t) {
-  t.deepEqual(
-    alex
-      .html(
-        `
-      <!doctype html>
-      <html>
-      <!-- The Chinese student walked to class. -->
-      <head><title>Church website</title></head>
-      <body>
-      <script>console.log("The boogeyman walked to class.")</script>
-      <style>.black {color: black;}</style>
-      <button disabled>Press me</button>
-      <p class="black">He walked to class.</p>
-      She walked to class.
-      <code>var adult = 2</code>
-      </body>
-      </html>
-      `
-      )
-      .messages.map(String),
-    [
-      '10:24-10:26: `He` may be insensitive, use `They`, `It` instead',
-      '11:7-11:10: `She` may be insensitive, use `They`, `It` instead'
-    ]
-  )
+  var fp = path.join(__dirname, 'fixtures', 'three.html')
+  var fixture = fs.readFileSync(fp)
+
+  t.deepEqual(alex.html(fixture).messages.map(String), [
+    '9:18-9:20: `He` may be insensitive, use `They`, `It` instead',
+    '10:1-10:4: `She` may be insensitive, use `They`, `It` instead'
+  ])
 })


### PR DESCRIPTION
This addresses @wooorm 's comments on and closes #201 .

This PR adds HTML parsing to the core API using `rehype-parse`–mirroring that of the work done for the CLI tool. It additionally adds an example usage to the documentation for `alex.html(value)` to expose the functionality to users.

I found this when searching for Hacktoberfest OSS projects to contribute to and yours was really special. Thanks for doing great work for inclusivity. 