### PR TITLE
Add install instructions for yarn users

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,9 @@ Using [npm][] (with [Node.js][node]):
 ```sh
 $ npm install alex --global
 ```
+
 Using [yarn][]:
+
 ```sh
 $ yarn global add alex
 ```

--- a/readme.md
+++ b/readme.md
@@ -34,10 +34,14 @@ Give **alex** a spin on the [Online demo »][demo].
 
 ## Install
 
-[npm][] (with [Node.js][node]):
+Using [npm][] (with [Node.js][node]):
 
 ```sh
 $ npm install alex --global
+```
+Using [yarn][]:
+```sh
+$ yarn global add alex
 ```
 
 ## Table of Contents
@@ -491,3 +495,5 @@ or community you agree to abide by its terms.
 [profanities]: https://github.com/retextjs/retext-profanities/blob/master/rules.md
 
 [equality]: https://github.com/retextjs/retext-equality/blob/master/rules.md
+
+[yarn]: https://yarnpkg.com/


### PR DESCRIPTION
Hey,

This is just a really small documentation change, but it basically just adds the command to install alex using yarn:
```sh
$ yarn global add alex
```
This might help new developers etc that use yarn at the recommendation of friends or colleagues, as npm can often be a bit tricky to understand 🙂
