### PR TITLE
Update Ava to @next version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "vfile-sort": "^2.0.0"
   },
   "devDependencies": {
-    "ava": "^0.25.0",
+    "ava": "^1.0.0-beta.8",
     "browserify": "^16.0.0",
     "execa": "^1.0.0",
     "nyc": "^13.0.0",


### PR DESCRIPTION
I updated the npm dependency ava to the beta version of 1.0.0, per our discussion in #229 

The tests all continue to pass without any additional changes. While I had to do some digging on the RegEx vulnerability, I found the root package causing it and submitted a PR to that package here:
https://github.com/alessioalex/git-spawned-stream/pull/5

When that gets re-released, we can close this issue for good. I'll go ahead and update the Github issue and continue monitoring.

Thanks again for an awesome project to help contribute to :). I'm having quite a bit of fun and learning a lot from this project.
<!--

Read the [contributing guidelines](https://github.com/get-alex/alex/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->
