### PR TITLE
Adding the ability to configure profanity plugin

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -121,7 +121,7 @@ function transform(options) {
   var settings = options || {}
   var plugins = [
     english,
-    profanities,
+    [profanities, {sureness: settings.profanitySureness}],
     [equality, {noBinary: settings.noBinary}]
   ]
 

--- a/index.js
+++ b/index.js
@@ -79,6 +79,18 @@ function htmlParse(value, config) {
 }
 
 // Alex, without the markdown.
-function noMarkdown(value) {
-  return core(value, makeText())
+function noMarkdown(value, config) {
+  var allow
+
+  if (Array.isArray(config)) {
+    allow = config
+  } else if (config) {
+    allow = config.allow
+  }
+
+  return core(
+    value,
+    makeText(config)
+      .use(filter, {allow: allow})
+  )
 }

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function core(value, processor) {
 
 // Alex.
 function alex(value, config) {
-  let allow
+  var allow
 
   if (Array.isArray(config)) {
     allow = config

--- a/index.js
+++ b/index.js
@@ -22,7 +22,9 @@ function makeText(config) {
   return unified()
     .use(english)
     .use(equality)
-    .use(profanities, config ? config.profanities : null)
+    .use(profanities, {
+      sureness: config && config.profanitySureness
+    })
 }
 
 // Alex’s core.

--- a/index.js
+++ b/index.js
@@ -88,9 +88,5 @@ function noMarkdown(value, config) {
     allow = config.allow
   }
 
-  return core(
-    value,
-    makeText(config)
-      .use(filter, {allow: allow})
-  )
+  return core(value, makeText(config).use(filter, {allow: allow}))
 }

--- a/index.js
+++ b/index.js
@@ -60,12 +60,20 @@ function alex(value, config) {
 }
 
 // Alex, for HTML.
-function htmlParse(value, allow) {
+function htmlParse(value, config) {
+  var allow
+
+  if (Array.isArray(config)) {
+    allow = config
+  } else if (config) {
+    allow = config.allow
+  }
+
   return core(
     value,
     unified()
       .use(html)
-      .use(rehype2retext, makeText())
+      .use(rehype2retext, makeText(config))
       .use(filter, {allow: allow})
   )
 }

--- a/index.js
+++ b/index.js
@@ -18,10 +18,12 @@ alex.text = noMarkdown
 alex.markdown = alex
 alex.html = htmlParse
 
-var text = unified()
-  .use(english)
-  .use(equality)
-  .use(profanities)
+function makeText(config) {
+  return unified()
+    .use(english)
+    .use(equality)
+    .use(profanities, config ? config.profanities : null)
+}
 
 // Alex’s core.
 function core(value, processor) {
@@ -36,13 +38,21 @@ function core(value, processor) {
 }
 
 // Alex.
-function alex(value, allow) {
+function alex(value, config) {
+  let allow
+
+  if (Array.isArray(config)) {
+    allow = config
+  } else if (config) {
+    allow = config.allow
+  }
+
   return core(
     value,
     unified()
       .use(markdown)
       .use(frontmatter, ['yaml', 'toml'])
-      .use(remark2retext, text)
+      .use(remark2retext, makeText(config))
       .use(filter, {allow: allow})
   )
 }
@@ -53,12 +63,12 @@ function htmlParse(value, allow) {
     value,
     unified()
       .use(html)
-      .use(rehype2retext, text)
+      .use(rehype2retext, makeText())
       .use(filter, {allow: allow})
   )
 }
 
 // Alex, without the markdown.
 function noMarkdown(value) {
-  return core(value, text)
+  return core(value, makeText())
 }

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,9 @@ $ yarn global add alex
     *   [.alexrc](#alexrc)
     *   [package.json](#packagejson)
     *   [Control](#control)
+*   [Configuring Profanity](#configuring-profanity)
+    *   [.alexrc](#alexrc-1)
+    *   [package.json](#packagejson-1)
 *   [Workflow](#workflow)
 *   [FAQ](#faq)
     *   [Why is this named alex?](#why-is-this-named-alex)
@@ -369,6 +372,49 @@ Multiple messages can be controlled in one go:
 ```md
 <!--alex ignore-->
 ```
+
+## Configuring Profanity
+
+### `.alexrc`
+
+### `package.json`
+
+The profanity checker in **alex** can be configured to define the level of
+“sureness” to warn for.  The underlying library uses
+[cuss](https://github.com/words/cuss) which has a dictionary of words that have
+a rating between 0 and 2 of how “sure” it is a profanity.  Here is the table from
+[the cuss documentation](https://github.com/words/cuss/blob/master/readme.md#cuss)
+
+| Rating | Use as a profanity | Use in clean text | Example |
+| ------ | ------------------ | ----------------- | ------- |
+| 2      | likely             | unlikely          | asshat  |
+| 1      | maybe              | maybe             | addict  |
+| 0      | unlikely           | likely            | beaver  |
+
+You can define what level of profanity you want **alex** to warn for in the
+`.alexrc` configuration:
+
+```json
+{
+  "profanitySureness": 1
+}
+```
+
+...or the `alex` field in `package.json`:
+
+```txt
+{
+  ...
+  "alex": {
+    "profanitySureness": 1
+  },
+  ...
+}
+```
+
+The `profanitySureness` is a number that _includes_ the level of profanity you
+want to check for.  For example, if you set it to 1 then it will warn for level 1
+and 2 profanities, but not for level 0 (unlikely).
 
 ## Workflow
 

--- a/readme.md
+++ b/readme.md
@@ -49,21 +49,18 @@ $ yarn global add alex
 
 *   [Command Line](#command-line)
 *   [API](#api)
-    *   [alex(value\[, allow\])](#alexvalue-allow)
-    *   [alex.markdown(value\[, allow\])](#alexmarkdownvalue-allow)
-    *   [alex.html(value)](#alexhtmlvalue)
-    *   [alex.text(value)](#alextextvalue)
+    *   [alex(value, config)](#alexvalue-config)
+    *   [alex.markdown(value, config)](#alexmarkdownvalue-config)
+    *   [alex.html(value, config)](#alexhtmlvalue-config)
+    *   [alex.text(value, config)](#alextextvalue-config)
 *   [Integrations](#integrations)
 *   [Support](#support)
 *   [Ignoring files](#ignoring-files)
 *   [.alexignore](#alexignore)
-*   [Ignoring messages](#ignoring-messages)
-    *   [.alexrc](#alexrc)
-    *   [package.json](#packagejson)
     *   [Control](#control)
-*   [Configuring Profanity](#configuring-profanity)
-    *   [.alexrc](#alexrc-1)
-    *   [package.json](#packagejson-1)
+*   [Configuration](#configuration)
+    *   [Ignoring messages](#ignoring-messages)
+    *   [Configuring Profanities](#configuring-profanities)
 *   [Workflow](#workflow)
 *   [FAQ](#faq)
     *   [Why is this named alex?](#why-is-this-named-alex)
@@ -120,9 +117,9 @@ $ npm install alex --save
 **alex** is also available as an AMD, CommonJS, and globals module,
 [uncompressed and compressed][releases].
 
-### `alex(value[, allow])`
+### `alex(value, config)`
 
-### `alex.markdown(value[, allow])`
+### `alex.markdown(value, config)`
 
 ###### Example
 
@@ -148,7 +145,7 @@ Yields:
 ###### Parameters
 
 *   `value` ([`VFile`][vfile] or `string`) — Markdown or plain-text
-*   `allow` (`Array.<string>`, optional) — List of allowed rules
+*   `config` (`Object`, optional) — See [Configuration](#configuration) section below
 
 ###### Returns
 
@@ -156,9 +153,9 @@ Yields:
 [`messages`][vfile-message] property, as demonstrated in the example
 above, as it holds the possible violations.
 
-### `alex.html(value)`
+### `alex.html(value, config)`
 
-Works just like [`alex()`][alex-api] and [`alex.text()`](#alextextvalue), but parses it as HTML.
+Works just like [`alex()`][alex-api] and [`alex.text()`](#alextextvalue-config), but parses it as HTML.
 It will break your writing out of its HTML-wrapped tags and examine them.
 
 ###### Example
@@ -182,7 +179,12 @@ Yields:
     fatal: false } ]
 ```
 
-### `alex.text(value)`
+###### Parameters
+
+*   `value` ([`VFile`][vfile] or `string`) — HTML content
+*   `config` (`Object`, optional) — See [Configuration](#configuration) section below
+
+### `alex.text(value, config)`
 
 Works just like [`alex()`][alex-api], but does not parse as markdown
 (thus things like code are not ignored)
@@ -209,6 +211,11 @@ Yields:
     ruleId: 'boogeyman-boogeywoman',
     fatal: false } ]
 ```
+
+###### Parameters
+
+*   `value` ([`VFile`][vfile] or `string`) — Text content
+*   `config` (`Object`, optional) — See [Configuration](#configuration) section below
 
 ## Integrations
 
@@ -266,41 +273,6 @@ looks as follows:
 # `node_modules` is ignored by default.
 example.md
 ```
-
-## Ignoring messages
-
-### `.alexrc`
-
-### `package.json`
-
-**alex** can silence messages through `.alexrc` configuration:
-
-```json
-{
-  "allow": ["boogeyman-boogeywoman"]
-}
-```
-
-...or the `alex` field in `package.json`:
-
-```txt
-{
-  ...
-  "alex": {
-    "allow": ["butt"]
-  },
-  ...
-}
-```
-
-The `allow` field is expected to be an array of rule identifier strings.
-
-All `allow` fields in all `package.json` and `.alexrc` files are
-detected and used when processing.
-
-Next to `allow`, `noBinary` can also be passed.  Setting it to true
-counts `he and she`, `garbageman or garbagewoman` and similar pairs
-as errors, whereas the default (`false`), treats it as OK.
 
 ### Control
 
@@ -373,11 +345,40 @@ Multiple messages can be controlled in one go:
 <!--alex ignore-->
 ```
 
-## Configuring Profanity
+## Configuration
 
-### `.alexrc`
+### Ignoring messages
 
-### `package.json`
+**alex** can silence messages through `.alexrc` configuration:
+
+```json
+{
+  "allow": ["boogeyman-boogeywoman"]
+}
+```
+
+...or the `alex` field in `package.json`:
+
+```txt
+{
+  ...
+  "alex": {
+    "allow": ["butt"]
+  },
+  ...
+}
+```
+
+The `allow` field is expected to be an array of rule identifier strings.
+
+All `allow` fields in all `package.json` and `.alexrc` files are
+detected and used when processing.
+
+Next to `allow`, `noBinary` can also be passed.  Setting it to true
+counts `he and she`, `garbageman or garbagewoman` and similar pairs
+as errors, whereas the default (`false`), treats it as OK.
+
+### Configuring Profanities
 
 The profanity checker in **alex** can be configured to define the level of
 “sureness” to warn for.  The underlying library uses
@@ -421,7 +422,7 @@ and 2 profanities, but not for level 0 (unlikely).
 The recommended workflow is to add **alex** to `package.json`
 and to run it with your tests in Travis.
 
-You can opt to ignore warnings through [alexrc][] files and
+You can opt to ignore warnings through [alexrc](#configuration) files and
 [control comments][control].  For example, with a `package.json`.
 
 A `package.json` file with [npm scripts][npm-scripts],
@@ -512,13 +513,11 @@ or community you agree to abide by its terms.
 
 [vfile-message]: https://github.com/vfile/vfile#vfilemessages
 
-[alex-api]: #alexvalue-allow
+[alex-api]: #alexvalue-config
 
 [literals]: https://github.com/syntax-tree/nlcst-is-literal#isliteralparent-index
 
 [alexignore]: #alexignore
-
-[alexrc]: #alexrc
 
 [control]: #control
 

--- a/test/api.js
+++ b/test/api.js
@@ -34,21 +34,23 @@ test('alex()', function(t) {
 })
 
 test('alex() with an allow array', function(t) {
-  let {messages} = alex(
+  var messages = alex(
     'Eric is pretty set on beating your butt for sheriff.',
     ['butt']
-  )
+  ).messages
+
   t.is(messages.length, 0)
 })
 
 test('alex() with profantity config', function(t) {
-  let {messages} = alex(
+  var messages = alex(
     'Eric, the asshat, is pretty set on beating your butt for sheriff.',
     {
       allow: ['asshat'],
       profanitySureness: 1
     }
-  )
+  ).messages
+
   t.is(messages.length, 0, 'We dont expect any messages')
 })
 

--- a/test/api.js
+++ b/test/api.js
@@ -46,9 +46,7 @@ test('alex() with profantity config', function(t) {
     'Eric, the asshat, is pretty set on beating your butt for sheriff.',
     {
       allow: ['asshat'],
-      profanities: {
-        sureness: 1
-      }
+      profanitySureness: 1
     }
   )
   t.is(messages.length, 0, 'We dont expect any messages')

--- a/test/api.js
+++ b/test/api.js
@@ -33,6 +33,19 @@ test('alex()', function(t) {
   )
 })
 
+test('alex() with profantity config', function(t) {
+  let {messages} = alex(
+    'Eric, the asshat, is pretty set on beating your butt for sheriff.',
+    {
+      allow: ['asshat'],
+      profanities: {
+        sureness: 1
+      }
+    }
+  )
+  t.is(messages.length, 0, 'We dont expect any messages')
+})
+
 test('alex.markdown()', function(t) {
   t.deepEqual(alex.markdown('The `boogeyman`.').messages.map(String), [])
 })

--- a/test/api.js
+++ b/test/api.js
@@ -33,6 +33,14 @@ test('alex()', function(t) {
   )
 })
 
+test('alex() with an allow array', function(t) {
+  let {messages} = alex(
+    'Eric is pretty set on beating your butt for sheriff.',
+    ['butt']
+  )
+  t.is(messages.length, 0)
+})
+
 test('alex() with profantity config', function(t) {
   let {messages} = alex(
     'Eric, the asshat, is pretty set on beating your butt for sheriff.',

--- a/test/api.js
+++ b/test/api.js
@@ -34,10 +34,9 @@ test('alex()', function(t) {
 })
 
 test('alex() with an allow array', function(t) {
-  var messages = alex(
-    'Eric is pretty set on beating your butt for sheriff.',
-    ['butt']
-  ).messages
+  var messages = alex('Eric is pretty set on beating your butt for sheriff.', [
+    'butt'
+  ]).messages
 
   t.is(messages.length, 0)
 })
@@ -59,9 +58,50 @@ test('alex.markdown()', function(t) {
 })
 
 test('alex.text()', function(t) {
-  t.deepEqual(alex.text('The `boogeyman`.').messages.map(String), [
-    '1:6-1:15: `boogeyman` may be insensitive, use `boogey` instead'
-  ])
+  t.deepEqual(
+    alex
+      .text(
+        [
+          'The `boogeyman` wrote all changes to the **master server**. Thus,',
+          'Eric is pretty set on beating your butt for sheriff.'
+        ].join('\n')
+      )
+      .messages.map(String),
+    [
+      '1:6-1:15: `boogeyman` may be insensitive, use `boogey` instead',
+      '2:36-2:40: Be careful with “butt”, it’s profane in some cases'
+    ]
+  )
+})
+
+test('alex.text() with allow config', function(t) {
+  t.deepEqual(
+    alex
+      .text(
+        [
+          'The `boogeyman` wrote all changes to the **master server**. Thus,',
+          'Eric is pretty set on beating your butt for sheriff.'
+        ].join('\n'),
+        {allow: ['butt']}
+      )
+      .messages.map(String),
+    ['1:6-1:15: `boogeyman` may be insensitive, use `boogey` instead']
+  )
+})
+
+test('alex.text() with allow array', function(t) {
+  t.deepEqual(
+    alex
+      .text(
+        [
+          'The `boogeyman` wrote all changes to the **master server**. Thus,',
+          'Eric is pretty set on beating your butt for sheriff.'
+        ].join('\n'),
+        ['butt']
+      )
+      .messages.map(String),
+    ['1:6-1:15: `boogeyman` may be insensitive, use `boogey` instead']
+  )
 })
 
 test('alex.html()', function(t) {
@@ -69,6 +109,27 @@ test('alex.html()', function(t) {
   var fixture = fs.readFileSync(fp)
 
   t.deepEqual(alex.html(fixture).messages.map(String), [
+    '9:18-9:20: `He` may be insensitive, use `They`, `It` instead',
+    '10:1-10:4: `She` may be insensitive, use `They`, `It` instead',
+    '11:36-11:40: Be careful with “butt”, it’s profane in some cases'
+  ])
+})
+
+test('alex.html() with allow config', function(t) {
+  var fp = path.join(__dirname, 'fixtures', 'three.html')
+  var fixture = fs.readFileSync(fp)
+
+  t.deepEqual(alex.html(fixture, {allow: ['butt']}).messages.map(String), [
+    '9:18-9:20: `He` may be insensitive, use `They`, `It` instead',
+    '10:1-10:4: `She` may be insensitive, use `They`, `It` instead'
+  ])
+})
+
+test('alex.html() with allow array', function(t) {
+  var fp = path.join(__dirname, 'fixtures', 'three.html')
+  var fixture = fs.readFileSync(fp)
+
+  t.deepEqual(alex.html(fixture, ['butt']).messages.map(String), [
     '9:18-9:20: `He` may be insensitive, use `They`, `It` instead',
     '10:1-10:4: `She` may be insensitive, use `They`, `It` instead'
   ])

--- a/test/cli.js
+++ b/test/cli.js
@@ -151,6 +151,30 @@ test('non-binary (optional)', function(t) {
   })
 })
 
+test('profanity (default)', function(t) {
+  var rp = path.join('test', 'fixtures', 'profanity', 'two.md')
+
+  return execa.stderr('./cli.js', [rp]).catch(function(error) {
+    var expected = [
+      rp,
+      '  1:5-1:11  warning  Be careful with “beaver”, it’s profane in some cases  beaver  retext-profanities',
+      '',
+      '⚠ 1 warning',
+      ''
+    ].join('\n')
+
+    t.is(error.stderr, expected)
+  })
+})
+
+test('profanity (profanitySureness: 1)', function(t) {
+  var rp = path.join('test', 'fixtures', 'profanity-sureness', 'two.md')
+
+  return execa.stderr('./cli.js', [rp]).then(function(result) {
+    t.is(result, rp + ': no issues found')
+  })
+})
+
 test('default globs', function(t) {
   return execa.stderr('./cli.js').then(function(stderr) {
     var expected = [

--- a/test/fixtures/profanity-sureness/.alexrc
+++ b/test/fixtures/profanity-sureness/.alexrc
@@ -1,0 +1,3 @@
+{
+  "profanitySureness": 1
+}

--- a/test/fixtures/profanity-sureness/two.md
+++ b/test/fixtures/profanity-sureness/two.md
@@ -1,0 +1,1 @@
+The beaver is a large, primarily nocturnal, semiaquatic rodent.

--- a/test/fixtures/profanity/two.md
+++ b/test/fixtures/profanity/two.md
@@ -1,0 +1,1 @@
+The beaver is a large, primarily nocturnal, semiaquatic rodent.

--- a/test/fixtures/three.html
+++ b/test/fixtures/three.html
@@ -8,6 +8,7 @@
 <button disabled>Press me</button>
 <p class="black">He walked to class.</p>
 She walked to class.
+Eric is pretty set on beating your butt for sheriff.
 <code>var adult = 2</code>
 </body>
 </html>


### PR DESCRIPTION
Howdy folks 👋 

This is essentially an extension of my work on https://github.com/retextjs/retext-profanities/pull/17 that is attempting to allow you to configure the level of "sureness" that a word is profane. 

This is also a "speculative" PR on how I think we might be able to expose this level of config for each of the plugins. Please let me know if it's along the right lines and I'll make sure that it makes sense on all of the exposed APIs 👍 or if you think there is a better way I am happy to move this PR in that direction