### PR TITLE
Add link to alex-browser-extension

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -227,6 +227,7 @@ Yields:
 *   Ember — [`yohanmishkin/ember-cli-alex`](https://github.com/yohanmishkin/ember-cli-alex)
 *   Probot — [`swinton/linter-alex`](https://github.com/swinton/linter-alex)
 *   Vim — [`w0rp/ale`](https://github.com/w0rp/ale)
+*   Browser Extension — [`skn0tt/alex-browser-extension`](https://github.com/skn0tt/alex-browser-extension)
 
 ## Support
 


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/get-alex/alex/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->

Alex is a great project - but I was quite surprised to see that there's no browser extension yet.
That's why I sat down to create [`alex-browser-extension`](https://github.com/skn0tt/alex-browser-extension). I already published it to Firefox; Chrome and Opera are still being reviewed.

This PR adds a link to the repo to the "Integrations" list.