### PR TITLE
Add support for a deny list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 alex.js
 alex.min.js
 yarn.lock
+*.tmp-browserify-*

--- a/filter.js
+++ b/filter.js
@@ -6,8 +6,17 @@ module.exports = filter
 
 function filter(options) {
   var settings = options || /* istanbul ignore next */ {}
+
+  if (settings.allow && settings.deny) {
+    throw new Error(
+      'Do not provide both allow and deny configuration parameters'
+    )
+  }
+
   return control({
     name: 'alex',
+    reset: Boolean(settings.deny),
+    enable: settings.deny,
     disable: settings.allow,
     source: ['retext-equality', 'retext-profanities']
   })

--- a/index.js
+++ b/index.js
@@ -28,9 +28,17 @@ function makeText(config) {
 }
 
 // Alex’s core.
-function core(value, processor) {
+function core(value, config, processor) {
+  var allow
+
+  if (Array.isArray(config)) {
+    allow = config
+  } else if (config) {
+    allow = config.allow
+  }
+
   var file = new VFile(value)
-  var tree = processor.parse(file)
+  var tree = processor.use(filter, {allow: allow}).parse(file)
 
   processor.runSync(tree, file)
 
@@ -41,52 +49,28 @@ function core(value, processor) {
 
 // Alex.
 function alex(value, config) {
-  var allow
-
-  if (Array.isArray(config)) {
-    allow = config
-  } else if (config) {
-    allow = config.allow
-  }
-
   return core(
     value,
+    config,
     unified()
       .use(markdown)
       .use(frontmatter, ['yaml', 'toml'])
       .use(remark2retext, makeText(config))
-      .use(filter, {allow: allow})
   )
 }
 
 // Alex, for HTML.
 function htmlParse(value, config) {
-  var allow
-
-  if (Array.isArray(config)) {
-    allow = config
-  } else if (config) {
-    allow = config.allow
-  }
-
   return core(
     value,
+    config,
     unified()
       .use(html)
       .use(rehype2retext, makeText(config))
-      .use(filter, {allow: allow})
   )
 }
 
 // Alex, without the markdown.
 function noMarkdown(value, config) {
-  var allow
-
-  if (Array.isArray(config)) {
-    allow = config
-  } else if (config) {
-    allow = config.allow
-  }
-
-  return core(value, makeText(config).use(filter, {allow: allow}))
+  return core(value, config, makeText(config))
 }

--- a/index.js
+++ b/index.js
@@ -30,15 +30,17 @@ function makeText(config) {
 // Alex’s core.
 function core(value, config, processor) {
   var allow
+  var deny
 
   if (Array.isArray(config)) {
     allow = config
   } else if (config) {
     allow = config.allow
+    deny = config.deny
   }
 
   var file = new VFile(value)
-  var tree = processor.use(filter, {allow: allow}).parse(file)
+  var tree = processor.use(filter, {allow: allow, deny: deny}).parse(file)
 
   processor.runSync(tree, file)
 

--- a/readme.md
+++ b/readme.md
@@ -242,7 +242,13 @@ exports.profanitySureness = Math.floor(Math.random() * 3)
 }
 ```
 
-The `allow` field should be an array of rules (the default is `[]`).
+The `allow` field should be an array of rules or `undefined` (the default is
+`undefined`).  When provided, the rules specified are skipped and not reported.
+
+The `deny` field should be an array of rules or `undefined` (the default is
+`undefined`).  When provided, *only* the rules specified are reported.
+
+You cannot use both `allow` and `deny` at the same time.
 
 The `noBinary` field should be a boolean (the default is `false`).
 When turned on (`true`), pairs such as `he and she` and `garbageman or

--- a/test/api.js
+++ b/test/api.js
@@ -60,6 +60,27 @@ test('alex()', function(t) {
     alex(
       'The boogeyman asked Eric, the asshat, to beat your butt for the sheriff.',
       {
+        deny: ['butt']
+      }
+    ).messages.map(String),
+    ['1:52-1:56: Be careful with `butt`, it’s profane in some cases'],
+    'should work with deny config'
+  )
+
+  t.throws(function() {
+    alex(
+      'The boogeyman asked Eric, the asshat, to beat your butt for the sheriff.',
+      {
+        allow: ['asshat'],
+        deny: ['boogeyman-boogeywoman']
+      }
+    )
+  }, 'should throw an error with allow and deny config')
+
+  t.deepEqual(
+    alex(
+      'The boogeyman asked Eric, the asshat, to beat your butt for the sheriff.',
+      {
         profanitySureness: 1
       }
     ).messages.map(String),
@@ -80,6 +101,18 @@ test('alex()', function(t) {
     ).messages.map(String),
     ['1:5-1:14: `boogeyman` may be insensitive, use `boogeymonster` instead'],
     'should work with allow and profanity config'
+  )
+
+  t.deepEqual(
+    alex(
+      'The boogeyman asked Eric, the asshat, to beat your butt for the sheriff.',
+      {
+        deny: ['boogeyman-boogeywoman'],
+        profanitySureness: 1
+      }
+    ).messages.map(String),
+    ['1:5-1:14: `boogeyman` may be insensitive, use `boogeymonster` instead'],
+    'should work with deny and profanity config'
   )
 
   t.deepEqual(alex.markdown, alex, 'alex.markdown is an alias of alex')
@@ -141,6 +174,29 @@ test('alex()', function(t) {
     alex
       .text(
         'The boogeyman asked Eric, the asshat, to beat your butt for the sheriff.',
+        {
+          deny: ['butt']
+        }
+      )
+      .messages.map(String),
+    ['1:52-1:56: Be careful with `butt`, it’s profane in some cases'],
+    'alex.text() with deny config'
+  )
+
+  t.throws(function() {
+    alex.text(
+      'The boogeyman asked Eric, the asshat, to beat your butt for the sheriff.',
+      {
+        allow: ['asshat'],
+        deny: ['boogeyman-boogeywoman']
+      }
+    )
+  }, 'alex.text() with allow and deny config')
+
+  t.deepEqual(
+    alex
+      .text(
+        'The boogeyman asked Eric, the asshat, to beat your butt for the sheriff.',
         {profanitySureness: 1}
       )
       .messages.map(String),
@@ -166,11 +222,26 @@ test('alex()', function(t) {
   )
 
   t.deepEqual(
+    alex
+      .text(
+        'The boogeyman asked Eric, the asshat, to beat your butt for the sheriff.',
+        {
+          deny: ['boogeyman-boogeywoman'],
+          profanitySureness: 1
+        }
+      )
+      .messages.map(String),
+    ['1:5-1:14: `boogeyman` may be insensitive, use `boogeymonster` instead'],
+    'alex.text() with deny and profanity config'
+  )
+
+  t.deepEqual(
     alex.html(html).messages.map(String),
     [
       '17:22-17:24: `He` may be insensitive, use `They`, `It` instead',
       '18:5-18:8: `She` may be insensitive, use `They`, `It` instead',
-      '18:61-18:65: Be careful with `butt`, it’s profane in some cases'
+      '18:36-18:42: Don’t use `asshat`, it’s profane',
+      '18:74-18:78: Be careful with `butt`, it’s profane in some cases'
     ],
     'alex.html()'
   )
@@ -179,7 +250,8 @@ test('alex()', function(t) {
     alex.html(html, ['butt']).messages.map(String),
     [
       '17:22-17:24: `He` may be insensitive, use `They`, `It` instead',
-      '18:5-18:8: `She` may be insensitive, use `They`, `It` instead'
+      '18:5-18:8: `She` may be insensitive, use `They`, `It` instead',
+      '18:36-18:42: Don’t use `asshat`, it’s profane'
     ],
     'alex.html() with allow array'
   )
@@ -188,16 +260,35 @@ test('alex()', function(t) {
     alex.html(html, {allow: ['butt']}).messages.map(String),
     [
       '17:22-17:24: `He` may be insensitive, use `They`, `It` instead',
-      '18:5-18:8: `She` may be insensitive, use `They`, `It` instead'
+      '18:5-18:8: `She` may be insensitive, use `They`, `It` instead',
+      '18:36-18:42: Don’t use `asshat`, it’s profane'
     ],
     'alex.html() with allow config'
   )
 
   t.deepEqual(
+    alex
+      .html(html, {
+        deny: ['butt']
+      })
+      .messages.map(String),
+    ['18:74-18:78: Be careful with `butt`, it’s profane in some cases'],
+    'alex.html() with deny config'
+  )
+
+  t.throws(function() {
+    alex.html(html, {
+      allow: ['he-she'],
+      deny: ['butt']
+    })
+  }, 'alex.html() with allow and deny config')
+
+  t.deepEqual(
     alex.html(html, {profanitySureness: 1}).messages.map(String),
     [
       '17:22-17:24: `He` may be insensitive, use `They`, `It` instead',
-      '18:5-18:8: `She` may be insensitive, use `They`, `It` instead'
+      '18:5-18:8: `She` may be insensitive, use `They`, `It` instead',
+      '18:36-18:42: Don’t use `asshat`, it’s profane'
     ],
     'alex.html() with profanity config'
   )
@@ -209,8 +300,22 @@ test('alex()', function(t) {
         profanitySureness: 1
       })
       .messages.map(String),
-    [],
-    'alex.html() with allow and profantity config'
+    ['18:36-18:42: Don’t use `asshat`, it’s profane'],
+    'alex.html() with allow and profanity config'
+  )
+
+  t.deepEqual(
+    alex
+      .html(html, {
+        deny: ['he-she'],
+        profanitySureness: 1
+      })
+      .messages.map(String),
+    [
+      '17:22-17:24: `He` may be insensitive, use `They`, `It` instead',
+      '18:5-18:8: `She` may be insensitive, use `They`, `It` instead'
+    ],
+    'alex.html() with deny and profanity config'
   )
 
   t.end()

--- a/test/api.js
+++ b/test/api.js
@@ -15,60 +15,96 @@ test('alex()', function(t) {
   t.deepEqual(
     alex(
       [
-        'The boogeyman wrote all changes to the **master server**. Thus,',
+        'The `boogeyman` wrote all changes to the **master server**. Thus,',
         'the slaves were read-only copies of master. But not to worry,',
-        'he was a cripple.',
+        'he was a _cripple_.',
         '',
-        'Eric is pretty set on beating your butt for sheriff.'
+        'Eric is pretty set on beating your butt for the sheriff.'
       ].join('\n')
     ).messages.map(String),
     [
-      '1:5-1:14: `boogeyman` may be insensitive, use `boogeymonster` instead',
-      '1:42-1:48: `master` / `slaves` may be insensitive, use ' +
-        '`primary` / `replica` instead',
+      '1:44-1:50: `master` / `slaves` may be insensitive, use `primary` / `replica` instead',
       '2:5-2:11: Don’t use `slaves`, it’s profane',
       '3:1-3:3: `he` may be insensitive, use `they`, `it` instead',
-      '3:10-3:17: `cripple` may be insensitive, use `person with a ' +
-        'limp` instead',
+      '3:11-3:18: `cripple` may be insensitive, use `person with a limp` instead',
       '5:36-5:40: Be careful with `butt`, it’s profane in some cases'
     ],
     'should work'
   )
 
   t.deepEqual(
-    alex('Eric is pretty set on beating your butt for sheriff.', ['butt'])
-      .messages,
-    [],
-    'should work with an allow array'
+    alex(
+      'The boogeyman asked Eric, the asshat, to beat your butt for the sheriff.',
+      ['butt']
+    ).messages.map(String),
+    [
+      '1:5-1:14: `boogeyman` may be insensitive, use `boogeymonster` instead',
+      '1:31-1:37: Don’t use `asshat`, it’s profane'
+    ],
+    'should work with allow array'
   )
 
   t.deepEqual(
-    alex('Eric, the asshat, is pretty set on beating your butt for sheriff.', {
-      allow: ['asshat'],
-      profanitySureness: 1
-    }).messages,
-    [],
-    'should work with profantity config'
+    alex(
+      'The boogeyman asked Eric, the asshat, to beat your butt for the sheriff.',
+      {allow: ['butt']}
+    ).messages.map(String),
+    [
+      '1:5-1:14: `boogeyman` may be insensitive, use `boogeymonster` instead',
+      '1:31-1:37: Don’t use `asshat`, it’s profane'
+    ],
+    'should work with allow config'
   )
 
   t.deepEqual(
-    alex.markdown('The `boogeyman`.').messages.map(String),
-    [],
-    'alex.markdown()'
+    alex(
+      'The boogeyman asked Eric, the asshat, to beat your butt for the sheriff.',
+      {
+        profanitySureness: 1
+      }
+    ).messages.map(String),
+    [
+      '1:5-1:14: `boogeyman` may be insensitive, use `boogeymonster` instead',
+      '1:31-1:37: Don’t use `asshat`, it’s profane'
+    ],
+    'should work with profanity config'
   )
+
+  t.deepEqual(
+    alex(
+      'The boogeyman asked Eric, the asshat, to beat your butt for the sheriff.',
+      {
+        allow: ['asshat'],
+        profanitySureness: 1
+      }
+    ).messages.map(String),
+    ['1:5-1:14: `boogeyman` may be insensitive, use `boogeymonster` instead'],
+    'should work with allow and profanity config'
+  )
+
+  t.deepEqual(alex.markdown, alex, 'alex.markdown is an alias of alex')
 
   t.deepEqual(
     alex
       .text(
         [
           'The `boogeyman` wrote all changes to the **master server**. Thus,',
-          'Eric is pretty set on beating your butt for sheriff.'
+          'the slaves were read-only copies of master. But not to worry,',
+          'he was a _cripple_.',
+          '',
+          'Eric is pretty set on beating your butt for the sheriff.'
         ].join('\n')
       )
       .messages.map(String),
     [
       '1:6-1:15: `boogeyman` may be insensitive, use `boogeymonster` instead',
-      '2:36-2:40: Be careful with `butt`, it’s profane in some cases'
+      '1:44-1:50: `master` / `slaves` may be insensitive, use ' +
+        '`primary` / `replica` instead',
+      '2:5-2:11: Don’t use `slaves`, it’s profane',
+      '3:1-3:3: `he` may be insensitive, use `they`, `it` instead',
+      '3:11-3:18: `cripple` may be insensitive, use `person with a ' +
+        'limp` instead',
+      '5:36-5:40: Be careful with `butt`, it’s profane in some cases'
     ],
     'alex.text()'
   )
@@ -76,29 +112,57 @@ test('alex()', function(t) {
   t.deepEqual(
     alex
       .text(
-        [
-          'The `boogeyman` wrote all changes to the **master server**. Thus,',
-          'Eric is pretty set on beating your butt for sheriff.'
-        ].join('\n'),
+        'The boogeyman asked Eric, the asshat, to beat your butt for the sheriff.',
+        ['butt']
+      )
+      .messages.map(String),
+    [
+      '1:5-1:14: `boogeyman` may be insensitive, use `boogeymonster` instead',
+      '1:31-1:37: Don’t use `asshat`, it’s profane'
+    ],
+    'alex.text() with allow array'
+  )
+
+  t.deepEqual(
+    alex
+      .text(
+        'The boogeyman asked Eric, the asshat, to beat your butt for the sheriff.',
         {allow: ['butt']}
       )
       .messages.map(String),
-    ['1:6-1:15: `boogeyman` may be insensitive, use `boogeymonster` instead'],
+    [
+      '1:5-1:14: `boogeyman` may be insensitive, use `boogeymonster` instead',
+      '1:31-1:37: Don’t use `asshat`, it’s profane'
+    ],
     'alex.text() with allow config'
   )
 
   t.deepEqual(
     alex
       .text(
-        [
-          'The `boogeyman` wrote all changes to the **master server**. Thus,',
-          'Eric is pretty set on beating your butt for sheriff.'
-        ].join('\n'),
-        ['butt']
+        'The boogeyman asked Eric, the asshat, to beat your butt for the sheriff.',
+        {profanitySureness: 1}
       )
       .messages.map(String),
-    ['1:6-1:15: `boogeyman` may be insensitive, use `boogeymonster` instead'],
-    'alex.text() with allow array'
+    [
+      '1:5-1:14: `boogeyman` may be insensitive, use `boogeymonster` instead',
+      '1:31-1:37: Don’t use `asshat`, it’s profane'
+    ],
+    'alex.text() with profanity config'
+  )
+
+  t.deepEqual(
+    alex
+      .text(
+        'The boogeyman asked Eric, the asshat, to beat your butt for the sheriff.',
+        {
+          allow: ['asshat'],
+          profanitySureness: 1
+        }
+      )
+      .messages.map(String),
+    ['1:5-1:14: `boogeyman` may be insensitive, use `boogeymonster` instead'],
+    'alex.text() with allow and profanity config'
   )
 
   t.deepEqual(
@@ -112,6 +176,15 @@ test('alex()', function(t) {
   )
 
   t.deepEqual(
+    alex.html(html, ['butt']).messages.map(String),
+    [
+      '17:22-17:24: `He` may be insensitive, use `They`, `It` instead',
+      '18:5-18:8: `She` may be insensitive, use `They`, `It` instead'
+    ],
+    'alex.html() with allow array'
+  )
+
+  t.deepEqual(
     alex.html(html, {allow: ['butt']}).messages.map(String),
     [
       '17:22-17:24: `He` may be insensitive, use `They`, `It` instead',
@@ -121,12 +194,23 @@ test('alex()', function(t) {
   )
 
   t.deepEqual(
-    alex.html(html, ['butt']).messages.map(String),
+    alex.html(html, {profanitySureness: 1}).messages.map(String),
     [
       '17:22-17:24: `He` may be insensitive, use `They`, `It` instead',
       '18:5-18:8: `She` may be insensitive, use `They`, `It` instead'
     ],
-    'alex.html() with allow array'
+    'alex.html() with profanity config'
+  )
+
+  t.deepEqual(
+    alex
+      .html(html, {
+        allow: ['he-she'],
+        profanitySureness: 1
+      })
+      .messages.map(String),
+    [],
+    'alex.html() with allow and profantity config'
   )
 
   t.end()

--- a/test/api.js
+++ b/test/api.js
@@ -104,9 +104,9 @@ test('alex()', function(t) {
   t.deepEqual(
     alex.html(html).messages.map(String),
     [
-      '9:18-9:20: `He` may be insensitive, use `They`, `It` instead',
-      '10:1-10:4: `She` may be insensitive, use `They`, `It` instead',
-      '11:36-11:40: Be careful with `butt`, it’s profane in some cases'
+      '17:22-17:24: `He` may be insensitive, use `They`, `It` instead',
+      '18:5-18:8: `She` may be insensitive, use `They`, `It` instead',
+      '18:61-18:65: Be careful with `butt`, it’s profane in some cases'
     ],
     'alex.html()'
   )
@@ -114,8 +114,8 @@ test('alex()', function(t) {
   t.deepEqual(
     alex.html(html, {allow: ['butt']}).messages.map(String),
     [
-      '9:18-9:20: `He` may be insensitive, use `They`, `It` instead',
-      '10:1-10:4: `She` may be insensitive, use `They`, `It` instead'
+      '17:22-17:24: `He` may be insensitive, use `They`, `It` instead',
+      '18:5-18:8: `She` may be insensitive, use `They`, `It` instead'
     ],
     'alex.html() with allow config'
   )
@@ -123,8 +123,8 @@ test('alex()', function(t) {
   t.deepEqual(
     alex.html(html, ['butt']).messages.map(String),
     [
-      '9:18-9:20: `He` may be insensitive, use `They`, `It` instead',
-      '10:1-10:4: `She` may be insensitive, use `They`, `It` instead'
+      '17:22-17:24: `He` may be insensitive, use `They`, `It` instead',
+      '18:5-18:8: `She` may be insensitive, use `They`, `It` instead'
     ],
     'alex.html() with allow array'
   )

--- a/test/cli.js
+++ b/test/cli.js
@@ -106,7 +106,7 @@ test('alex-cli', function(t) {
 
     function onexec(err, stdout, stderr) {
       t.deepEqual(
-        [err.code, /2 warnings/.test(stderr), stdout],
+        [err.code, /3 warnings/.test(stderr), stdout],
         [1, true, ''],
         'should work'
       )
@@ -138,7 +138,7 @@ test('alex-cli', function(t) {
 
     function onexec(err, stdout, stderr) {
       t.deepEqual(
-        [err.code, /9 warnings/.test(stderr), stdout],
+        [err.code, /10 warnings/.test(stderr), stdout],
         [1, true, ''],
         'should work'
       )

--- a/test/fixtures/three.html
+++ b/test/fixtures/three.html
@@ -15,8 +15,8 @@
     </style>
     <button disabled>Press me</button>
     <p class="black">He walked to class.</p>
-    She walked to class. Eric is pretty set on beating your butt for the
-    sheriff.
+    She walked to class. Eric, the asshat, is pretty set on beating your butt
+    for the sheriff.
     <code>var adult = 2</code>
   </body>
 </html>

--- a/test/fixtures/three.html
+++ b/test/fixtures/three.html
@@ -1,14 +1,22 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-<!-- The Chinese student walked to class. -->
-<head><title>Church website</title></head>
-<body>
-<script>console.log("The boogeyman walked to class.")</script>
-<style>.black {color: black;}</style>
-<button disabled>Press me</button>
-<p class="black">He walked to class.</p>
-She walked to class.
-Eric is pretty set on beating your butt for sheriff.
-<code>var adult = 2</code>
-</body>
+  <!-- The Chinese student walked to class. -->
+  <head>
+    <title>Church website</title>
+  </head>
+  <body>
+    <script>
+      console.log('The boogeyman walked to class.')
+    </script>
+    <style>
+      .black {
+        color: black;
+      }
+    </style>
+    <button disabled>Press me</button>
+    <p class="black">He walked to class.</p>
+    She walked to class. Eric is pretty set on beating your butt for the
+    sheriff.
+    <code>var adult = 2</code>
+  </body>
 </html>


### PR DESCRIPTION
Sometimes it can be useful to be able to chose which rules to _include_, rather than exclude. For instance, while building a Slack bot to run Alex on our conversations, we found that we got far too many false positives, and wanted to be able to specify which rules to use. This feature supports that without any changes to current behaviour.

If both `allow` and `deny` are provided, we throw an error. I tried to follow the pattern of errors thrown elsewhere, but let me know if there's a more "Alex" way of handling conflicting configuration.

There is a small refactor to unify applying the filter in `core()`, that will make it easier to add features like this in future.

In order to be confident in these changes, I have also make the test suite more thorough, including adding more configuration combination testing.
