### PR TITLE
Clarify rule usage for config file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -240,6 +240,7 @@ exports.profanitySureness = Math.floor(Math.random() * 3)
 ```
 
 The `allow` field should be an array of rules (the default is `[]`).
+This array should contain rule identifiers, not individual words. Rule identifierss can be found in the [retext.js](https://github.com/retextjs) rules files, [https://github.com/retextjs/retext-equality/blob/master/rules.md](retextjs/retext-equality) and [https://github.com/retextjs/retext-profanities/blob/master/rules.md](retxtjs/retext-profanities).
 
 The `noBinary` field should be a boolean (the default is `false`).
 When turned on (`true`), pairs such as `he and she`, `garbageman or


### PR DESCRIPTION
This change is intended to clarify that the `allow` array in the `.alexrc` file should be populated with rule identifiers, and not individual words. This confusion caused me some trouble when implementing this tool recently, specifically around the word `disabled` which is in a rule controlled by the identifier `invalid`.

<!--
Read the [contributing guidelines](https://github.com/get-alex/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/get-alex/.github/blob/master/support.md
https://github.com/get-alex/.github/blob/master/contributing.md
-->
