### PR TITLE
Bumped meow version to address yargs-parser vulnerability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "cli.js"
   ],
   "dependencies": {
-    "meow": "^5.0.0",
+    "meow": "^7.0.0",
     "rehype-parse": "^6.0.0",
     "rehype-retext": "^2.0.1",
     "remark-frontmatter": "^1.1.0",


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/get-alex/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/get-alex/.github/blob/master/support.md
https://github.com/get-alex/.github/blob/master/contributing.md
-->

This PR bumps `meow` up to latest, as their latest bumps a dependency of theirs, `yargs-parser` and addresses a vulnerability.  https://www.npmjs.com/advisories/1500

I tested `alex` with the latest `meow`; tests pass and it seems to run as the version with `meow==5.0.0` did.