### PR TITLE
Remove vscode extension from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -102,7 +102,6 @@ like][literals] are not warned about.
 
 *   Atom — [`get-alex/atom-linter-alex`](https://github.com/get-alex/atom-linter-alex)
 *   Sublime — [`sindresorhus/SublimeLinter-contrib-alex`](https://github.com/sindresorhus/SublimeLinter-contrib-alex)
-*   Visual Studio Code — [`shinnn/vscode-alex`](https://github.com/shinnn/vscode-alex)
 *   Gulp — [`dustinspecker/gulp-alex`](https://github.com/dustinspecker/gulp-alex)
 *   Slack — [`keoghpe/alex-slack`](https://github.com/keoghpe/alex-slack)
 *   Ember — [`yohanmishkin/ember-cli-alex`](https://github.com/yohanmishkin/ember-cli-alex)


### PR DESCRIPTION
The linked Visual Studio Code extension ([https://github.com/shinnn/vscode-alex](https://github.com/shinnn/vscode-alex)) is no longer available in the VS Code extension list. There is a fork however it doesn't function either. This PR will remove the reference from `readme.md`.