### PR TITLE
Split CLI into interpreter+app scripts for usage in in-band tooling within Yarn Plug-n-Play Environments

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,106 @@
+'use strict'
+
+var PassThrough = require('stream').PassThrough
+var engine = require('unified-engine')
+var unified = require('unified')
+var markdown = require('remark-parse')
+var htmlParser = require('rehype-parse')
+var frontmatter = require('remark-frontmatter')
+var english = require('retext-english')
+var remark2retext = require('remark-retext')
+var rehype2retext = require('rehype-retext')
+var report = require('vfile-reporter')
+var equality = require('retext-equality')
+var profanities = require('retext-profanities')
+var filter = require('./filter')
+
+var textExtensions = [
+  'txt',
+  'text',
+  'md',
+  'markdown',
+  'mkd',
+  'mkdn',
+  'mkdown',
+  'ron'
+]
+var htmlExtensions = ['htm', 'html']
+
+module.exports = function app(
+  input,
+  {stdin, text, html, diff, quiet, why}
+) {
+  var extensions = html ? htmlExtensions : textExtensions
+  var defaultGlobs = ['{docs/**/,doc/**/,}*.{' + extensions.join(',') + '}']
+  var silentlyIgnore
+  var globs
+
+  if (stdin) {
+    if (input.length !== 0) {
+      throw new Error('Do not pass globs with `--stdin`')
+    }
+  } else if (input.length === 0) {
+    globs = defaultGlobs
+    silentlyIgnore = true
+  } else {
+    globs = input
+  }
+
+  engine(
+    {
+      processor: unified(),
+      files: globs,
+      extensions: extensions,
+      configTransform: transform,
+      output: false,
+      out: false,
+      streamError: new PassThrough(),
+      rcName: '.alexrc',
+      packageField: 'alex',
+      ignoreName: '.alexignore',
+      silentlyIgnore: silentlyIgnore,
+      frail: true,
+      defaultConfig: transform()
+    },
+    function(err, code, result) {
+      var out = report(err || result.files, {
+        verbose: why,
+        quiet: quiet
+      })
+
+      if (out) {
+        console.error(out)
+      }
+
+      process.exit(code)
+    }
+  )
+
+  function transform(options) {
+    var settings = options || {}
+    var plugins = [
+      english,
+      [profanities, {sureness: settings.profanitySureness}],
+      [equality, {noBinary: settings.noBinary}]
+    ]
+
+    if (html) {
+      plugins = [htmlParser, [rehype2retext, unified().use({plugins: plugins})]]
+    } else if (!text) {
+      plugins = [
+        markdown,
+        [frontmatter, ['yaml', 'toml']],
+        [remark2retext, unified().use({plugins: plugins})]
+      ]
+    }
+
+    plugins.push([filter, {allow: settings.allow}])
+
+    /* istanbul ignore if - hard to check. */
+    if (diff) {
+      plugins.push(diff)
+    }
+
+    return {plugins: plugins}
+  }
+}

--- a/app.js
+++ b/app.js
@@ -26,7 +26,13 @@ var textExtensions = [
 ]
 var htmlExtensions = ['htm', 'html']
 
-module.exports = function app(input, {stdin, text, html, diff, quiet, why}) {
+/**
+ * Executes the CLI Application
+ * @param {string[]} input
+ * @param {{stdin?: boolean, text?: boolean, html?: boolean, diff?: boolean, quiet?: boolean, why?: boolean}} flags
+ * @returns {Promise<number>} The exit code of the task
+ */
+module.exports = function(input, {stdin, text, html, diff, quiet, why} = {}) {
   var extensions = html ? htmlExtensions : textExtensions
   var defaultGlobs = ['{docs/**/,doc/**/,}*.{' + extensions.join(',') + '}']
   var silentlyIgnore

--- a/app.js
+++ b/app.js
@@ -26,10 +26,7 @@ var textExtensions = [
 ]
 var htmlExtensions = ['htm', 'html']
 
-module.exports = function app(
-  input,
-  {stdin, text, html, diff, quiet, why}
-) {
+module.exports = function app(input, {stdin, text, html, diff, quiet, why}) {
   var extensions = html ? htmlExtensions : textExtensions
   var defaultGlobs = ['{docs/**/,doc/**/,}*.{' + extensions.join(',') + '}']
   var silentlyIgnore
@@ -46,35 +43,37 @@ module.exports = function app(
     globs = input
   }
 
-  engine(
-    {
-      processor: unified(),
-      files: globs,
-      extensions: extensions,
-      configTransform: transform,
-      output: false,
-      out: false,
-      streamError: new PassThrough(),
-      rcName: '.alexrc',
-      packageField: 'alex',
-      ignoreName: '.alexignore',
-      silentlyIgnore: silentlyIgnore,
-      frail: true,
-      defaultConfig: transform()
-    },
-    function(err, code, result) {
-      var out = report(err || result.files, {
-        verbose: why,
-        quiet: quiet
-      })
+  return new Promise(resolve => {
+    engine(
+      {
+        processor: unified(),
+        files: globs,
+        extensions: extensions,
+        configTransform: transform,
+        output: false,
+        out: false,
+        streamError: new PassThrough(),
+        rcName: '.alexrc',
+        packageField: 'alex',
+        ignoreName: '.alexignore',
+        silentlyIgnore: silentlyIgnore,
+        frail: true,
+        defaultConfig: transform()
+      },
+      function(err, code, result) {
+        var out = report(err || result.files, {
+          verbose: why,
+          quiet: quiet
+        })
 
-      if (out) {
-        console.error(out)
+        if (out) {
+          console.error(out)
+        }
+
+        resolve(code)
       }
-
-      process.exit(code)
-    }
-  )
+    )
+  })
 
   function transform(options) {
     var settings = options || {}

--- a/app.js
+++ b/app.js
@@ -32,7 +32,7 @@ var htmlExtensions = ['htm', 'html']
  * @param {{stdin?: boolean, text?: boolean, html?: boolean, diff?: boolean, quiet?: boolean, why?: boolean}} flags
  * @returns {Promise<number>} The exit code of the task
  */
-module.exports = function(input, {stdin, text, html, diff, quiet, why} = {}) {
+module.exports = function(input, {stdin, text, html, diff, quiet, why}) {
   var extensions = html ? htmlExtensions : textExtensions
   var defaultGlobs = ['{docs/**/,doc/**/,}*.{' + extensions.join(',') + '}']
   var silentlyIgnore

--- a/cli.js
+++ b/cli.js
@@ -45,4 +45,4 @@ var cli = meow(
   }
 )
 
-app(cli.input, cli.flags).then(code => process.exit(code))
+app(cli.input, cli.flags).then(process.exit)

--- a/cli.js
+++ b/cli.js
@@ -45,5 +45,4 @@ var cli = meow(
   }
 )
 
-
-app(cli.input, cli.flags)
+app(cli.input, cli.flags).then(code => process.exit(code))

--- a/cli.js
+++ b/cli.js
@@ -1,35 +1,10 @@
 #!/usr/bin/env node
 'use strict'
 
-var PassThrough = require('stream').PassThrough
 var notifier = require('update-notifier')
 var meow = require('meow')
-var engine = require('unified-engine')
-var unified = require('unified')
-var markdown = require('remark-parse')
-var html = require('rehype-parse')
-var frontmatter = require('remark-frontmatter')
-var english = require('retext-english')
-var remark2retext = require('remark-retext')
-var rehype2retext = require('rehype-retext')
-var report = require('vfile-reporter')
-var equality = require('retext-equality')
-var profanities = require('retext-profanities')
-var diff = require('unified-diff')
 var pack = require('./package')
-var filter = require('./filter')
-
-var textExtensions = [
-  'txt',
-  'text',
-  'md',
-  'markdown',
-  'mkd',
-  'mkdn',
-  'mkdown',
-  'ron'
-]
-var htmlExtensions = ['htm', 'html']
+var app = require('./app')
 
 // Update messages.
 notifier({pkg: pack}).notify()
@@ -70,77 +45,5 @@ var cli = meow(
   }
 )
 
-// Set-up.
-var extensions = cli.flags.html ? htmlExtensions : textExtensions
-var defaultGlobs = ['{docs/**/,doc/**/,}*.{' + extensions.join(',') + '}']
-var silentlyIgnore
-var globs
 
-if (cli.flags.stdin) {
-  if (cli.input.length !== 0) {
-    throw new Error('Do not pass globs with `--stdin`')
-  }
-} else if (cli.input.length === 0) {
-  globs = defaultGlobs
-  silentlyIgnore = true
-} else {
-  globs = cli.input
-}
-
-engine(
-  {
-    processor: unified(),
-    files: globs,
-    extensions: extensions,
-    configTransform: transform,
-    output: false,
-    out: false,
-    streamError: new PassThrough(),
-    rcName: '.alexrc',
-    packageField: 'alex',
-    ignoreName: '.alexignore',
-    silentlyIgnore: silentlyIgnore,
-    frail: true,
-    defaultConfig: transform()
-  },
-  function(err, code, result) {
-    var out = report(err || result.files, {
-      verbose: cli.flags.why,
-      quiet: cli.flags.quiet
-    })
-
-    if (out) {
-      console.error(out)
-    }
-
-    process.exit(code)
-  }
-)
-
-function transform(options) {
-  var settings = options || {}
-  var plugins = [
-    english,
-    [profanities, {sureness: settings.profanitySureness}],
-    [equality, {noBinary: settings.noBinary}]
-  ]
-
-  if (cli.flags.html) {
-    plugins = [html, [rehype2retext, unified().use({plugins: plugins})]]
-  } else if (!cli.flags.text) {
-    plugins = [
-      markdown,
-      [frontmatter, ['yaml', 'toml']],
-      [remark2retext, unified().use({plugins: plugins})]
-    ]
-  }
-
-  plugins.push([filter, {allow: settings.allow}])
-
-  /* istanbul ignore if - hard to check. */
-  if (cli.flags.diff) {
-    plugins.push(diff)
-  }
-
-  return {plugins: plugins}
-}
+app(cli.input, cli.flags)

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
   "files": [
     "index.js",
     "filter.js",
-    "cli.js"
+    "cli.js",
+    "app.js"
   ],
   "dependencies": {
     "meow": "^7.0.0",


### PR DESCRIPTION
When using Yarn Plug-n-Play, shell scripts are not hoisted unless they are direct dependencies. This affects some of our shared build-tooling which depends on orchestrating various CLI tasks such as Alex. 

This PR adds the ability to call the Alex CLI from Node by using `app.js`; this is easier than using the Alex API. The `cli.js` script has been refactored to thunk over to `app.js`. It's scope has been reduced to version-checking and argument parsing.

`app.js` exposes a function that returns a Promise with the result code to emit. If you prefer, I can replace the Promise with a callback.