### PR TITLE
Fix `noBinary` in api

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,9 @@ alex.html = htmlParse
 function makeText(config) {
   return unified()
     .use(english)
-    .use(equality)
+    .use(equality, {
+      noBinary: config && config.noBinary
+    })
     .use(profanities, {
       sureness: config && config.profanitySureness
     })


### PR DESCRIPTION
In order to utilize the configuration for noBinary values in the Alex core (non-cli) the argument needs to be passed to retext-equality, like already done with retext-profanities
