### PR TITLE
Fix outdated links in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -617,9 +617,9 @@ Lots of [people helped since][contributors]!
 
 [vfile]: https://github.com/vfile/vfile
 
-[profanities]: https://github.com/retextjs/retext-profanities/blob/master/rules.md
+[profanities]: https://github.com/retextjs/retext-profanities/blob/main/rules.md
 
-[equality]: https://github.com/retextjs/retext-equality/blob/master/rules.md
+[equality]: https://github.com/retextjs/retext-equality/blob/main/rules.md
 
 [vfile-message]: https://github.com/vfile/vfile#vfilemessages
 


### PR DESCRIPTION
They weren't completely broken but they were pointing to the master branch in repos that had renamed it to main

<!--
Read the [contributing guidelines](https://github.com/get-alex/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/get-alex/.github/blob/master/support.md
https://github.com/get-alex/.github/blob/master/contributing.md
-->
