### PR TITLE
Add `main` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "Daan <daan@devign.it>"
   ],
   "type": "module",
+  "exports": "./index.js",
   "sideEffects": false,
   "bin": "cli.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "Daan <daan@devign.it>"
   ],
   "type": "module",
-  "exports": "./index.js",
+  "main": "index.js",
   "sideEffects": false,
   "bin": "cli.js",
   "types": "index.d.ts",


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/get-alex/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/get-alex/.github/blob/main/support.md
https://github.com/get-alex/.github/blob/main/contributing.md
-->

Hi there! I'm attempting to use the JS API with the latest version (i.e., `alex@11.0.0`) and I'm seeing the following deprecation warning:

```
(node:65358) [DEP0151] DeprecationWarning: No "main" or "exports" field defined in the package.json for [redacted]/node_modules/alex/ resolving the main entry point "index.js", imported from [redacted]
```

Per [the docs for `DEP0151`](https://nodejs.org/api/deprecations.html#dep0151-main-index-lookup-and-extension-searching):

> With this deprecation, all ES module main entry point resolutions require an explicit ["exports" or "main" entry](https://nodejs.org/api/packages.html#main-entry-point-export) with the exact file extension.

I figured it was safe to add an `exports` field that points to the `index.js` file, similar to [the recommended approach in the Node.js docs](https://nodejs.org/api/packages.html#main-entry-point-export).

Thanks in advance! Big fan of this project 🙂