### PR TITLE
Add missing `supports-color` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "retext-english": "^4.0.0",
     "retext-equality": "~6.6.0",
     "retext-profanities": "~7.2.0",
+    "supports-color": "^9.4.0",
     "unified": "^10.0.0",
     "unified-diff": "^4.0.0",
     "unified-engine": "^10.0.0",


### PR DESCRIPTION
👋 Our `package-lock.json` file is a mess for a variety of reasons I won't bore you with but while removing an ancient version of `webpack-dev-server` that used `supports-color` from our application it ended up deleting `node_modules/supports-color`; however because Alex has an _implicit_ dependency on this by way of `vfile-reporter` it left `node_modules/vfile-reporter/node_modules/supports-color` alone.

Unfortunately because this is an implicit and not an **explicit** dependency Alex began to throw the following error for us:

```sh
node:internal/modules/esm/resolve:853
  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
        ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'supports-color' imported from /Users/erunion/redacted/path/to/codebase/node_modules/alex/cli.js
    at packageResolve (node:internal/modules/esm/resolve:853:9)
    at moduleResolve (node:internal/modules/esm/resolve:910:20)
    at defaultResolve (node:internal/modules/esm/resolve:1130:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:396:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:365:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:240:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:85:39)
    at link (node:internal/modules/esm/module_job:84:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}

Node.js v20.11.1
```

Installing `supports-color` as a development dependency of our application places `supports-color` back into the root `node_modules` directory and makes Alex work again.

Because Alex directly depends on this module it should list it as an explicit dependency.